### PR TITLE
RemovePIIJob: select PII rather than update/delete it

### DIFF
--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -29,7 +29,7 @@ class RemovePIIJob extends Job implements GenericParameterJob {
 
 		$user = $userFactory->newFromName( $this->username );
 
-		$username = $user->getName();
+		$username = $this->username;
 
 		if ( !$user ) {
 			$this->setLastError( "User {$username} is not a valid name" );

--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -2,13 +2,10 @@
 
 namespace Miraheze\RemovePII;
 
-use CentralAuthUser;
 use Exception;
-use ExtensionRegistry;
 use GenericParameterJob;
 use Job;
 use MediaWiki\MediaWikiServices;
-use User;
 
 class RemovePIIJob extends Job implements GenericParameterJob {
 	/** @var string */

--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -261,10 +261,10 @@ class RemovePIIJob extends Job implements GenericParameterJob {
 
 		$output = [];
 		foreach ( $tableSelections as $key => $value ) {
-			if ( $dbw->tableExists( $key, __METHOD__ ) ) {
+			if ( $dbr->tableExists( $key, __METHOD__ ) ) {
 				foreach ( $value as $name => $fields ) {
 					try {
-						$output[$key] = $dbw->select(
+						$output[$key] = $dbr->select(
 							$key,
 							$fields['fields'],
 							$fields['where'],

--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -282,7 +282,8 @@ class RemovePIIJob extends Job implements GenericParameterJob {
 		}
 
 		$output['email'] = $user->getEmail();
-		file_put_contents( "/srv/mediawiki/cache/RemovePII/{$GLOBALS['DBname']}", $output );
+		$output['realname'] = $user->getRealName();
+		file_put_contents( "/srv/mediawiki/cache/RemovePII/{$username}-{$GLOBALS['DBname']}", $output );
 
 		return true;
 	}


### PR DESCRIPTION
This is purely a concept, DO NOT MERGE!

```php
$username = 'username';
$centralUser = CentralAuthUser::getInstanceByName( $username );
$jobQueueGroupFactory = MediaWiki\MediaWikiServices::getInstance()->getJobQueueGroupFactory();
foreach ( $centralUser->listAttached() as $database ) {
	$jobQueueGroupFactory->makeJobQueueGroup( $database )->push(
		new RemovePIIJob( [ 'username' => $username ] )
	);
}
```
