### PR TITLE
Don't trigger Status::newFatal( 'centralauth-rename-notinstalled' ) on mw 1.40+

### DIFF
--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -158,7 +158,9 @@ class SpecialRemovePII extends FormSpecialPage {
 			return Status::newFatal( 'removepii-centralauth-notinstalled' );
 		}
 
-		if ( version_compare( MW_VERSION, '1.40', '<' ) && !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) &&
+		    !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
+		) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}
 

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -159,7 +159,7 @@ class SpecialRemovePII extends FormSpecialPage {
 		}
 
 		if ( version_compare( MW_VERSION, '1.40', '<' ) &&
-		    !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
+			!ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
 		) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -158,7 +158,7 @@ class SpecialRemovePII extends FormSpecialPage {
 			return Status::newFatal( 'removepii-centralauth-notinstalled' );
 		}
 
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) && !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}
 


### PR DESCRIPTION
Renameuser is now bundled into core and thus the extension is of no use.