### PR TITLE
Inject CentralAuth services again

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,7 +8,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.38.0"
+		"MediaWiki": ">= 1.41.0"
 	},
 	"MessagesDirs": {
 		"RemovePII": [

--- a/extension.json
+++ b/extension.json
@@ -57,6 +57,11 @@
 				"HttpRequestFactory",
 				"JobQueueGroupFactory",
 				"UserFactory"
+			],
+			"optional_services": [
+				"CentralAuth.CentralAuthAntiSpoofManager",
+				"CentralAuth.CentralAuthDatabaseManager",
+				"CentralAuth.GlobalRenameUserValidator"
 			]
 		}
 	},

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -19,7 +19,6 @@ use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
 use MediaWiki\Extension\CentralAuth\Widget\HTMLGlobalUserTextField;
 use MediaWiki\Http\HttpRequestFactory;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserFactory;
 use SpecialPage;
 use Status;

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -52,8 +52,8 @@ class SpecialRemovePII extends FormSpecialPage {
 	 * @param HttpRequestFactory $httpRequestFactory
 	 * @param JobQueueGroupFactory $jobQueueGroupFactory
 	 * @param UserFactory $userFactory
-  	 * @param ?CentralAuthAntiSpoofManager $centralAuthAntiSpoofManager
-  	 * @param ?CentralAuthDatabaseManager $centralAuthDatabaseManager
+	 * @param ?CentralAuthAntiSpoofManager $centralAuthAntiSpoofManager
+	 * @param ?CentralAuthDatabaseManager $centralAuthDatabaseManager
 	 * @param ?GlobalRenameUserValidator $globalRenameUserValidator
 	 */
 	public function __construct(

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -179,7 +179,7 @@ class SpecialRemovePII extends FormSpecialPage {
 	 * @return Status
 	 */
 	public function validateCentralAuth( array $formData ) {
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'CentralAuth' ) || !$this->globalRenameUserValidator ) {
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'CentralAuth' ) ) {
 			return Status::newFatal( 'removepii-centralauth-notinstalled' );
 		}
 


### PR DESCRIPTION
* Reverts #72 but uses optional_services instead to prevent fataling on non-CentralAuth wikis