### PR TITLE
RemovePIIJob: Use doAtomicSection

### DIFF
--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -10,6 +10,7 @@ use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\User;
 use UserProfilePage;
+use Wikimedia\Rdbms\IDatabase;
 
 class RemovePIIJob extends Job implements GenericParameterJob {
 

--- a/includes/RemovePIIJob.php
+++ b/includes/RemovePIIJob.php
@@ -147,11 +147,6 @@ class RemovePIIJob extends Job implements GenericParameterJob {
 				],
 			],
 
-
-
-
-
-
 		];
 
 		$tableUpdates = [


### PR DESCRIPTION
* Fixes an issue under MW 1.42 where if the transaction throws an error and we catch it, we can't use dbw. You need to either open a new connection, use doAtomicSection or use checks so the query doesn't error.
* Simplify the logic for some of the tables.