### PR TITLE
Update SpecialPage groups

### DIFF
--- a/includes/SpecialGenerateRandomHash.php
+++ b/includes/SpecialGenerateRandomHash.php
@@ -74,7 +74,7 @@ class SpecialGenerateRandomHash extends FormSpecialPage {
 	 * @return string
 	 */
 	protected function getGroupName() {
-		return 'wikimanage';
+		return 'wiki';
 	}
 
 	/**

--- a/includes/SpecialRemovePII.php
+++ b/includes/SpecialRemovePII.php
@@ -354,7 +354,7 @@ class SpecialRemovePII extends FormSpecialPage {
 	 * @return string
 	 */
 	protected function getGroupName() {
-		return 'wikimanage';
+		return 'login';
 	}
 
 	/**


### PR DESCRIPTION
Factoring out wikimanage because that means extensions rely on MirahezeMagic for the i18n and we dont want to copy rhe i18n to numerous extensions.